### PR TITLE
Bug 500006 - [newindex] An ElementChangedEvent fired on the consumpti…

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
@@ -32,6 +32,7 @@ import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.core.ClasspathEntry;
 import org.eclipse.jdt.internal.core.JavaCorePreferenceInitializer;
 import org.eclipse.jdt.internal.core.JavaElement;
+import org.eclipse.jdt.internal.core.JavaElementDelta;
 import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.JavaProject;
 import org.eclipse.jdt.internal.core.NameLookup;
@@ -242,6 +243,9 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 			StringBuffer buffer = new StringBuffer();
 			for (int i=0, length= this.deltas.length; i<length; i++) {
 				IJavaElementDelta delta = this.deltas[i];
+				if (((JavaElementDelta) delta).ignoreFromTests) {
+					continue;
+				}
 				IJavaElementDelta[] children = delta.getAffectedChildren();
 				int childrenLength=children.length;
 				IResourceDelta[] resourceDeltas = delta.getResourceDeltas();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DeltaProcessingState.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DeltaProcessingState.java
@@ -650,7 +650,9 @@ public class DeltaProcessingState implements IResourceChangeListener, Indexer.Li
 	public void consume(IndexerEvent event) {
 		if (JavaIndex.isEnabled()) {
 			DeltaProcessor processor = getDeltaProcessor();
-			processor.notifyAndFire(event.getDelta());
+			JavaElementDelta delta = (JavaElementDelta) event.getDelta();
+			delta.ignoreFromTests = true;
+			processor.notifyAndFire(delta);
 			this.deltaProcessors.set(null);
 		}
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaElementDelta.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaElementDelta.java
@@ -81,6 +81,8 @@ public class JavaElementDelta extends SimpleDelta implements IJavaElementDelta {
 	 */
 	Map<Key, Integer> childIndex;
 
+	public boolean ignoreFromTests = false;
+
 	/**
 	 * The delta key
 	 */


### PR DESCRIPTION
…on of IndexingEvent breaks tests.

Change-Id: I0000000000000000000000000000000000000000
Signed-off-by: Alexander Rookey atrookey@gmail.com
